### PR TITLE
fix: throw invalid path if its not an absolute path

### DIFF
--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRInputsValidator.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRInputsValidator.kt
@@ -2,6 +2,9 @@ package io.ionic.libs.ionfiletransferlib.helpers
 
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRException
 import java.util.regex.Pattern
+import java.io.File
+import java.net.URI
+import java.net.URISyntaxException
 
 internal class IONFLTRInputsValidator {
 
@@ -26,7 +29,25 @@ internal class IONFLTRInputsValidator {
      * @return true if path is valid, false otherwise
      */
     private fun isPathValid(path: String?): Boolean {
-        return !path.isNullOrBlank()
+        if (path.isNullOrBlank()) {
+            return false
+        }
+
+        return try {
+            val resolvedPath: String
+            if (path.startsWith("file://")) {
+                val uri = URI(path)
+                if (uri.path == null) {
+                    return false
+                }
+                resolvedPath = uri.path
+            } else {
+                resolvedPath = path
+            }
+            File(resolvedPath).isAbsolute
+        } catch (e: URISyntaxException) {
+            false
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
This PR adjusts the `isValidPath` method to check if the path we are trying to access / write to is actually available on the filesystem. Previously, it only checked if the string was not empty. This matches the [iOS implementation ](https://github.com/ionic-team/ion-ios-filetransfer/blob/ab31b6dd0e502ae42e4de12b37ba8d57478fb4a9/IONFileTransferLib/Helpers/IONFLTRInputsValidator.swift#L43) so that if a path such as "IMG_01.jpeg" is passed as a parameter for downloading, it will fail before trying to execute the download. Previously, a path like this would pass the input validation and only fail after trying to write to the file path, which would result in a "File Does Not Exist" error instead of an "Invalid Path" error.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Tested with ODC NewFileSampleApp