### PR TITLE
fix: encode special characters in file path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfiletransfer-android</artifactId>
-    <version>0.0.1-dev-3</version>
+    <version>0.0.1-dev-4</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfiletransfer-android</artifactId>
-    <version>0.0.1-dev-2</version>
+    <version>0.0.1-dev-3</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfiletransfer-android</artifactId>
-    <version>0.0.1-dev-1</version>
+    <version>0.0.1-dev-2</version>
 </project>

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -118,10 +118,10 @@ class IONFLTRController internal constructor(
      */
     private fun prepareForDownload(options: IONFLTRDownloadOptions): Pair<File, HttpURLConnection> {
         // Validate inputs
-        inputsValidator.validateTransferInputs(options.url, options.filePath)
+        val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
+        inputsValidator.validateTransferInputs(options.url, normalizedFilePath)
 
         // Create parent directories if needed
-        val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
         val targetFile = File(normalizedFilePath)
         fileHelper.createParentDirectories(targetFile)
 

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -118,10 +118,10 @@ class IONFLTRController internal constructor(
      */
     private fun prepareForDownload(options: IONFLTRDownloadOptions): Pair<File, HttpURLConnection> {
         // Validate inputs
-        val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
-        inputsValidator.validateTransferInputs(options.url, normalizedFilePath)
+        inputsValidator.validateTransferInputs(options.url, options.filePath)
 
         // Create parent directories if needed
+        val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
         val targetFile = File(normalizedFilePath)
         fileHelper.createParentDirectories(targetFile)
 

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -23,6 +23,7 @@ import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.net.HttpURLConnection
+import java.net.URI
 
 /**
  * Entry point in IONFileTransferLib-Android
@@ -118,11 +119,11 @@ class IONFLTRController internal constructor(
      */
     private fun prepareForDownload(options: IONFLTRDownloadOptions): Pair<File, HttpURLConnection> {
         // Validate inputs
-        inputsValidator.validateTransferInputs(options.url, options.filePath)
+        val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
+        inputsValidator.validateTransferInputs(options.url, normalizedFilePath)
 
         // Create parent directories if needed
-        val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
-        val targetFile = File(normalizedFilePath)
+        val targetFile = File(URI(normalizedFilePath).path)
         fileHelper.createParentDirectories(targetFile)
 
         // Setup connection

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
@@ -23,7 +23,7 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
     fun getFileToUploadInfo(filePath: String): FileToUploadInfo {
         return if (filePath.startsWith("content://")) {
             val uri = filePath.toUri()
-            val cursor = contentResolver.query(uri, null, null, null, null)
+            val cursor = contentResolver.query(uri, null, null, null, null) 
                 ?: throw IONFLTRException.FileDoesNotExist()
             cursor.use {
                 val fileName = getNameForContentUri(cursor)
@@ -45,7 +45,6 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
 
     /**
      * Normalizes a file path by removing URI prefixes like "file://", "file:/", etc.
-     *
      *
      * @param filePath The file path that might contain URI prefixes
      * @return Cleaned file path without URI prefixes

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
@@ -12,8 +12,6 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
 import androidx.core.net.toUri
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
     /**
@@ -47,18 +45,17 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
 
     /**
      * Normalizes a file path by removing URI prefixes like "file://", "file:/", etc.
-     * and encodes special characters
+     *
      *
      * @param filePath The file path that might contain URI prefixes
      * @return Cleaned file path without URI prefixes
      */
     fun normalizeFilePath(filePath: String): String {
-        val path = URLEncoder.encode(filePath, StandardCharsets.UTF_8.toString())
         return when {
-            path.startsWith("file://") -> path.removePrefix("file://")
-            path.startsWith("file:/") -> path.removePrefix("file:/")
-            path.startsWith("file:") -> path.removePrefix("file:")
-            else -> path
+            filePath.startsWith("file://") -> filePath.removePrefix("file://")
+            filePath.startsWith("file:/") -> filePath.removePrefix("file:/")
+            filePath.startsWith("file:") -> filePath.removePrefix("file:")
+            else -> filePath
         }
     }
 

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
@@ -12,6 +12,9 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
 import androidx.core.net.toUri
+import java.net.URI
+import java.net.URLDecoder
+import java.net.URLEncoder
 
 internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
     /**
@@ -35,7 +38,7 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
             }
         } else {
             val cleanFilePath = normalizeFilePath(filePath)
-            val fileObject = File(cleanFilePath)
+            val fileObject = File(URI(cleanFilePath).path)
             if (!fileObject.exists()) {
                 throw IONFLTRException.FileDoesNotExist()
             }
@@ -50,12 +53,17 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
      * @return Cleaned file path without URI prefixes
      */
     fun normalizeFilePath(filePath: String): String {
-        return when {
+        val path = when {
             filePath.startsWith("file://") -> filePath.removePrefix("file://")
             filePath.startsWith("file:/") -> filePath.removePrefix("file:/")
             filePath.startsWith("file:") -> filePath.removePrefix("file:")
             else -> filePath
         }
+
+        return URLEncoder.encode(
+            URLDecoder.decode(path, Charsets.UTF_8.toString()),
+            Charsets.UTF_8.toString()
+        ).replace("+", "%20")
     }
 
     /**

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
@@ -12,6 +12,8 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
 import androidx.core.net.toUri
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
     /**
@@ -23,7 +25,7 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
     fun getFileToUploadInfo(filePath: String): FileToUploadInfo {
         return if (filePath.startsWith("content://")) {
             val uri = filePath.toUri()
-            val cursor = contentResolver.query(uri, null, null, null, null) 
+            val cursor = contentResolver.query(uri, null, null, null, null)
                 ?: throw IONFLTRException.FileDoesNotExist()
             cursor.use {
                 val fileName = getNameForContentUri(cursor)
@@ -45,16 +47,18 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
 
     /**
      * Normalizes a file path by removing URI prefixes like "file://", "file:/", etc.
+     * and encodes special characters
      *
      * @param filePath The file path that might contain URI prefixes
      * @return Cleaned file path without URI prefixes
      */
     fun normalizeFilePath(filePath: String): String {
+        val path = URLEncoder.encode(filePath, StandardCharsets.UTF_8.toString())
         return when {
-            filePath.startsWith("file://") -> filePath.removePrefix("file://")
-            filePath.startsWith("file:/") -> filePath.removePrefix("file:/")
-            filePath.startsWith("file:") -> filePath.removePrefix("file:")
-            else -> filePath
+            path.startsWith("file://") -> path.removePrefix("file://")
+            path.startsWith("file:/") -> path.removePrefix("file:/")
+            path.startsWith("file:") -> path.removePrefix("file:")
+            else -> path
         }
     }
 

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRInputsValidator.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRInputsValidator.kt
@@ -35,21 +35,8 @@ internal class IONFLTRInputsValidator {
         }
 
         return try {
-            val resolvedPath: String
-            if (path.startsWith("file://")) {
-                val encodedPath = URLEncoder.encode(
-                    path.replace("file://", ""),
-                    Charsets.UTF_8.toString()
-                ).replace("+", "%20")
-                val uri = URI(encodedPath)
-                if (uri.path == null) {
-                    return false
-                }
-                resolvedPath = uri.path
-            } else {
-                resolvedPath = path
-            }
-            File(resolvedPath).isAbsolute
+            val uri = URI(path).path
+            File(uri).isAbsolute
         } catch (e: URISyntaxException) {
             false
         }

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRInputsValidator.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRInputsValidator.kt
@@ -5,6 +5,7 @@ import java.util.regex.Pattern
 import java.io.File
 import java.net.URI
 import java.net.URISyntaxException
+import java.net.URLEncoder
 
 internal class IONFLTRInputsValidator {
 
@@ -36,7 +37,11 @@ internal class IONFLTRInputsValidator {
         return try {
             val resolvedPath: String
             if (path.startsWith("file://")) {
-                val uri = URI(path)
+                val encodedPath = URLEncoder.encode(
+                    path.replace("file://", ""),
+                    Charsets.UTF_8.toString()
+                ).replace("+", "%20")
+                val uri = URI(encodedPath)
                 if (uri.path == null) {
                     return false
                 }


### PR DESCRIPTION
## Description
This PR uses the encoded URI to reference the file instead of file paths so that it can handle both encoded and not encoded file paths.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)