### PR TITLE
fix: Properly initializing Cursor for content URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 1.0.1
+
+### 2025-08-01
+
+- Fix uploading files with content URIs by properly initializing Cursor.
 
 ### 2025-06-26
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfiletransfer-android</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </project>

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRFileHelper.kt
@@ -26,8 +26,10 @@ internal class IONFLTRFileHelper(val contentResolver: ContentResolver) {
     fun getFileToUploadInfo(filePath: String): FileToUploadInfo {
         return if (filePath.startsWith("content://")) {
             val uri = filePath.toUri()
-            val cursor = contentResolver.query(uri, null, null, null, null) 
-                ?: throw IONFLTRException.FileDoesNotExist()
+            val cursor = contentResolver.query(uri, null, null, null, null)
+            if (cursor?.moveToFirst() != true) {
+                throw IONFLTRException.FileDoesNotExist()
+            }
             cursor.use {
                 val fileName = getNameForContentUri(cursor)
                     ?: throw IONFLTRException.FileDoesNotExist()


### PR DESCRIPTION
## Description

Reported in https://github.com/ionic-team/capacitor-file-transfer/issues/9, a capacitor plugin was returning a `content://` URI, and the plugin was returning an error, that was basically due to the way file properties were being retrieved with `android.database.Cursor`.

The fix involved correctly initializing the Cursor by calling `moveToFirst` before getting any specific properties from it.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly