### PR TITLE
fix: Removed explicit setting of `HttpURLConnection` `Accept-Encoding` header value as it disables automatic response decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.2
+
+### 2025-12-22
+
+- Fix processing of HTTP responses by removing unnecessary gzip header.
+
 ## 1.0.1
 
 ### 2025-08-01

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfiletransfer-android</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 </project>

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -9,7 +9,6 @@ import io.ionic.libs.ionfiletransferlib.helpers.assertSuccessHttpResponse
 import io.ionic.libs.ionfiletransferlib.helpers.runCatchingIONFLTRExceptions
 import io.ionic.libs.ionfiletransferlib.helpers.use
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRDownloadOptions
-import io.ionic.libs.ionfiletransferlib.model.IONFLTRException
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRProgressStatus
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRTransferComplete
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRTransferResult
@@ -186,9 +185,7 @@ class IONFLTRController internal constructor(
             BufferedOutputStream(fileOut).use { outputStream ->
                 val buffer = ByteArray(BUFFER_SIZE)
                 var bytesRead: Int
-                val lengthComputable = connection.contentEncoding.let {
-                    it == null || it.equals("gzip", ignoreCase = true)
-                } && contentLength > 0
+                val lengthComputable = contentLength > 0
                 var totalBytesRead: Long = 0
 
                 while (inputStream.read(buffer).also { bytesRead = it } != -1) {

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -285,9 +285,6 @@ class IONFLTRController internal constructor(
             }
         }
 
-        // gzip to allow for better progress tracking
-        connection.setRequestProperty("Accept-Encoding", "gzip")
-
         if (useChunkedMode) {
             connection.setChunkedStreamingMode(BUFFER_SIZE)
             connection.setRequestProperty("Transfer-Encoding", "chunked")


### PR DESCRIPTION
## Description
It seems like [IONFLTRController.kt#L289](https://github.com/ionic-team/ion-android-filetransfer/blob/main/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt#L289) is explicitly setting the `Accept-Encoding` header's value to `gzip` which results in responses from servers supporting response compression to be encoded. This however doesn't seem to be correctly handled in `processUploadResponse` which just reads the connection's input stream as text (`connection.inputStream.bufferedReader().readText()`). This unfortunately results in the responseBody being returned as a byte array converted to a string which isn't of much use. 
I believe this is also the cause of https://github.com/ionic-team/capacitor-file-transfer/issues/26

Android's [HttpURLConnection documentation](https://developer.android.com/reference/java/net/HttpURLConnection.html) indicates that specifically setting the `Accept-Encoding` header value disables automatic compression:

> Setting the Accept-Encoding request header explicitly disables automatic decompression and leaves the response headers intact; callers must handle decompression as needed, according to the Content-Encoding header of the response. 

Removing this header value leads to the response being automatically decompressed and returned correctly but it isn't yet clear as to why it was needed in the first place.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
This was tested by uploading a file to an endpoint which respects the `Accept-Encoding` header value and returns a response body encoded to suit the request's desired encoding.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly