### PR TITLE
fix: upload with params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.3
+
+### 2026-01-08
+
+- Fix uploading files with params.
+
 ## 1.0.2
 
 ### 2025-12-22

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfiletransfer-android</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 </project>

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -2,7 +2,6 @@ package io.ionic.libs.ionfiletransferlib
 
 import android.content.Context
 import io.ionic.libs.ionfiletransferlib.helpers.FileToUploadInfo
-import io.ionic.libs.ionfiletransferlib.helpers.HttpConnectionSetup
 import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRConnectionHelper
 import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRFileHelper
 import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRInputsValidator
@@ -57,9 +56,9 @@ class IONFLTRController internal constructor(
     fun downloadFile(options: IONFLTRDownloadOptions): Flow<IONFLTRTransferResult> = flow {
         runCatchingIONFLTRExceptions {
             // Prepare for download
-            val (targetFile, connectionSetup) = prepareForDownload(options)
+            val (targetFile, connection) = prepareForDownload(options)
 
-            connectionSetup.connection.use { conn ->
+            connection.use { conn ->
                 // Execute the download and handle response
                 val contentLength = beginDownload(conn)
 
@@ -95,9 +94,9 @@ class IONFLTRController internal constructor(
     fun uploadFile(options: IONFLTRUploadOptions): Flow<IONFLTRTransferResult> = flow {
         runCatchingIONFLTRExceptions {
             // Prepare for upload
-            val (file, connectionSetup) = prepareForUpload(options)
+            val (file, connection) = prepareForUpload(options)
 
-            connectionSetup.connection.use { conn ->
+            connection.use { conn ->
                 // Execute the upload and handle response
                 val multiPartFormData = beginUpload(conn, options, file)
 
@@ -117,7 +116,7 @@ class IONFLTRController internal constructor(
     /**
      * Prepares for download by validating inputs, creating directories and setting up connection.
      */
-    private fun prepareForDownload(options: IONFLTRDownloadOptions): Pair<File, HttpConnectionSetup> {
+    private fun prepareForDownload(options: IONFLTRDownloadOptions): Pair<File, HttpURLConnection> {
         // Validate inputs
         val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
         inputsValidator.validateTransferInputs(options.url, normalizedFilePath)
@@ -127,9 +126,11 @@ class IONFLTRController internal constructor(
         fileHelper.createParentDirectories(targetFile)
 
         // Setup connection
-        val connectionSetup = connectionHelper.setupConnection(options.url, options.httpOptions)
+        val connection = connectionHelper.setupConnection(options.url, options.httpOptions).let {
+            connectionHelper.appendParamsToUrl(options.url, it, options.httpOptions, useChunkedMode = false)
+        }
 
-        return Pair(targetFile, connectionSetup)
+        return Pair(targetFile, connection)
     }
 
     /**
@@ -243,7 +244,7 @@ class IONFLTRController internal constructor(
     /**
      * Prepares for upload by validating inputs and setting up connection.
      */
-    private fun prepareForUpload(options: IONFLTRUploadOptions): Pair<FileToUploadInfo, HttpConnectionSetup> {
+    private fun prepareForUpload(options: IONFLTRUploadOptions): Pair<FileToUploadInfo, HttpURLConnection> {
         // Validate inputs
         inputsValidator.validateTransferInputs(options.url, options.filePath)
 
@@ -251,9 +252,11 @@ class IONFLTRController internal constructor(
         val file = fileHelper.getFileToUploadInfo(options.filePath)
 
         // Setup connection
-        val connectionSetup = connectionHelper.setupConnection(options.url, options.httpOptions)
+        val connection = connectionHelper.setupConnection(options.url, options.httpOptions).let {
+            connectionHelper.appendParamsToUrl(options.url, it, options.httpOptions, options.chunkedMode)
+        }
 
-        return Pair(file, connectionSetup)
+        return Pair(file, connection)
     }
 
     /**
@@ -269,18 +272,16 @@ class IONFLTRController internal constructor(
     ): Pair<String, String>? {
         var multiPartUpload = false
         // Set content type if not already set
-        if (!options.httpOptions.headers.containsKey("Content-Type")) {
+        if (connectionHelper.useMultipartFormData(options.httpOptions) && !useChunkedMode) {
+            multiPartUpload = true
+            connection.setRequestProperty(
+                "Content-Type",
+                "multipart/form-data; boundary=$BOUNDARY"
+            )
+        } else if (!options.httpOptions.headers.containsKey("Content-Type")) {
             val mimeType = options.mimeType ?: fileHelper.getMimeType(options.filePath)
             ?: "application/octet-stream"
-            if (isPostOrPutMethod(options.httpOptions.method)) {
-                multiPartUpload = true
-                connection.setRequestProperty(
-                    "Content-Type",
-                    "multipart/form-data; boundary=$BOUNDARY"
-                )
-            } else {
-                connection.setRequestProperty("Content-Type", mimeType)
-            }
+            connection.setRequestProperty("Content-Type", mimeType)
         }
 
         if (useChunkedMode) {
@@ -315,8 +316,9 @@ class IONFLTRController internal constructor(
         val boundary = "$LINE_START$BOUNDARY$LINE_END"
 
         val beforeData = buildString {
-            // Write additional form parameters if any
-            options.formParams?.forEach { (key, value) ->
+            // Write form parameters using the available attributes
+            val allParams = (options.formParams ?: emptyMap()) + options.httpOptions.params
+            allParams.forEach { (key, value) ->
                 append(boundary)
                 val paramHeader = "Content-Disposition: form-data; name=\"$key\"$LINE_END$LINE_END"
                 val paramValue = "$value$LINE_END"
@@ -396,7 +398,7 @@ class IONFLTRController internal constructor(
             emit(createUploadFileProgress(bytes = 0, total = 0))
             return 0L
         }
-        
+
         var totalBytesWritten: Long
 
         connection.outputStream.use { connOutputStream ->
@@ -446,15 +448,5 @@ class IONFLTRController internal constructor(
                 )
             )
         )
-    }
-
-    /**
-     * Checks if the HTTP method is either POST or PUT.
-     *
-     * @param method The HTTP method to check
-     * @return True if the method is POST or PUT, false otherwise
-     */
-    private fun isPostOrPutMethod(method: String): Boolean {
-        return method.equals("POST", ignoreCase = true) || method.equals("PUT", ignoreCase = true)
     }
 }

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -2,6 +2,7 @@ package io.ionic.libs.ionfiletransferlib
 
 import android.content.Context
 import io.ionic.libs.ionfiletransferlib.helpers.FileToUploadInfo
+import io.ionic.libs.ionfiletransferlib.helpers.HttpConnectionSetup
 import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRConnectionHelper
 import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRFileHelper
 import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRInputsValidator
@@ -56,9 +57,9 @@ class IONFLTRController internal constructor(
     fun downloadFile(options: IONFLTRDownloadOptions): Flow<IONFLTRTransferResult> = flow {
         runCatchingIONFLTRExceptions {
             // Prepare for download
-            val (targetFile, connection) = prepareForDownload(options)
+            val (targetFile, connectionSetup) = prepareForDownload(options)
 
-            connection.use { conn ->
+            connectionSetup.connection.use { conn ->
                 // Execute the download and handle response
                 val contentLength = beginDownload(conn)
 
@@ -94,9 +95,9 @@ class IONFLTRController internal constructor(
     fun uploadFile(options: IONFLTRUploadOptions): Flow<IONFLTRTransferResult> = flow {
         runCatchingIONFLTRExceptions {
             // Prepare for upload
-            val (file, connection) = prepareForUpload(options)
+            val (file, connectionSetup) = prepareForUpload(options)
 
-            connection.use { conn ->
+            connectionSetup.connection.use { conn ->
                 // Execute the upload and handle response
                 val multiPartFormData = beginUpload(conn, options, file)
 
@@ -116,7 +117,7 @@ class IONFLTRController internal constructor(
     /**
      * Prepares for download by validating inputs, creating directories and setting up connection.
      */
-    private fun prepareForDownload(options: IONFLTRDownloadOptions): Pair<File, HttpURLConnection> {
+    private fun prepareForDownload(options: IONFLTRDownloadOptions): Pair<File, HttpConnectionSetup> {
         // Validate inputs
         val normalizedFilePath = fileHelper.normalizeFilePath(options.filePath)
         inputsValidator.validateTransferInputs(options.url, normalizedFilePath)
@@ -126,9 +127,9 @@ class IONFLTRController internal constructor(
         fileHelper.createParentDirectories(targetFile)
 
         // Setup connection
-        val connection = connectionHelper.setupConnection(options.url, options.httpOptions)
+        val connectionSetup = connectionHelper.setupConnection(options.url, options.httpOptions)
 
-        return Pair(targetFile, connection)
+        return Pair(targetFile, connectionSetup)
     }
 
     /**
@@ -242,7 +243,7 @@ class IONFLTRController internal constructor(
     /**
      * Prepares for upload by validating inputs and setting up connection.
      */
-    private fun prepareForUpload(options: IONFLTRUploadOptions): Pair<FileToUploadInfo, HttpURLConnection> {
+    private fun prepareForUpload(options: IONFLTRUploadOptions): Pair<FileToUploadInfo, HttpConnectionSetup> {
         // Validate inputs
         inputsValidator.validateTransferInputs(options.url, options.filePath)
 
@@ -250,9 +251,9 @@ class IONFLTRController internal constructor(
         val file = fileHelper.getFileToUploadInfo(options.filePath)
 
         // Setup connection
-        val connection = connectionHelper.setupConnection(options.url, options.httpOptions)
+        val connectionSetup = connectionHelper.setupConnection(options.url, options.httpOptions)
 
-        return Pair(file, connection)
+        return Pair(file, connectionSetup)
     }
 
     /**

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRConnectionHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRConnectionHelper.kt
@@ -46,11 +46,11 @@ fun HttpURLConnection.assertSuccessHttpResponse() {
 /**
  * Helper class for setting up HTTP connections with proper configuration.
  */
-class IONFLTRConnectionHelper {
+internal class IONFLTRConnectionHelper {
     /**
      * Sets up the HTTP connection with the provided options.
      */
-    fun setupConnection(urlString: String, httpOptions: IONFLTRTransferHttpOptions): HttpURLConnection {
+    fun setupConnection(urlString: String, httpOptions: IONFLTRTransferHttpOptions): HttpConnectionSetup {
         val url = URL(urlString)
         val connection = url.openConnection() as HttpURLConnection
         
@@ -65,44 +65,58 @@ class IONFLTRConnectionHelper {
         httpOptions.headers.forEach { (key, value) ->
             connection.setRequestProperty(key, value)
         }
-        
+
+        val isHttpGET = httpOptions.method.equals("GET", ignoreCase = true)
+        val encodeParams = httpOptions.shouldEncodeUrlParams && isHttpGET
+
+        // Set redirect handling
+        connection.instanceFollowRedirects = !httpOptions.disableRedirects
+
+        // Set SSL factory if provided
+        if (httpOptions.sslSocketFactory != null && connection is javax.net.ssl.HttpsURLConnection) {
+            connection.sslSocketFactory = httpOptions.sslSocketFactory
+        }
+
         // Set parameters
+        var paramString = ""
         if (httpOptions.params.isNotEmpty()) {
-            val paramString = buildString {
+            paramString = buildString {
                 httpOptions.params.forEach { (key, values) ->
                     values.forEach { value ->
                         if (isNotEmpty()) append("&")
-                        val encodedKey = if (httpOptions.shouldEncodeUrlParams) {
+                        val encodedKey = if (encodeParams) {
                             java.net.URLEncoder.encode(key, StandardCharsets.UTF_8.name())
                         } else key
-                        val encodedValue = if (httpOptions.shouldEncodeUrlParams) {
+                        val encodedValue = if (encodeParams) {
                             java.net.URLEncoder.encode(value, StandardCharsets.UTF_8.name())
                         } else value
                         append("$encodedKey=$encodedValue")
                     }
                 }
             }
-            
-            if (httpOptions.method.equals("GET", ignoreCase = true)) {
+
+            // for requests other than GET, params will be written in the request body.
+            if (isHttpGET) {
                 val separator = if (urlString.contains("?")) "&" else "?"
                 val newUrl = URL("$urlString$separator$paramString")
-                return newUrl.openConnection() as HttpURLConnection
+                return HttpConnectionSetup(
+                    connection = newUrl.openConnection() as HttpURLConnection,
+                    paramStringToWrite = ""
+                )
             } else {
-                connection.doOutput = true
+                // TODO move this block elsewhere
+                /*connection.doOutput = true
                 connection.outputStream.use { os ->
                     os.write(paramString.toByteArray())
-                }
+                }*/
             }
         }
         
-        // Set redirect handling
-        connection.instanceFollowRedirects = !httpOptions.disableRedirects
-        
-        // Set SSL factory if provided
-        if (httpOptions.sslSocketFactory != null && connection is javax.net.ssl.HttpsURLConnection) {
-            connection.sslSocketFactory = httpOptions.sslSocketFactory
-        }
-        
-        return connection
+        return HttpConnectionSetup(connection = connection, paramStringToWrite = paramString)
     }
-} 
+}
+
+internal data class HttpConnectionSetup(
+    val connection: HttpURLConnection,
+    val paramStringToWrite: String
+)

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRConnectionHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRConnectionHelper.kt
@@ -26,7 +26,7 @@ inline fun <R> HttpURLConnection.use(block: (HttpURLConnection) -> R): R {
  * Extension function to assert that an HTTP response was successful (2xx status code).
  * If the response was not successful, throws an IONFLTRException.HttpError with details
  * from the error stream.
- * 
+ *
  * @throws IONFLTRException.HttpError if the response code is not in the 200-299 range
  */
 
@@ -50,24 +50,21 @@ internal class IONFLTRConnectionHelper {
     /**
      * Sets up the HTTP connection with the provided options.
      */
-    fun setupConnection(urlString: String, httpOptions: IONFLTRTransferHttpOptions): HttpConnectionSetup {
+    fun setupConnection(urlString: String, httpOptions: IONFLTRTransferHttpOptions): HttpURLConnection {
         val url = URL(urlString)
         val connection = url.openConnection() as HttpURLConnection
-        
+
         // Set method
         connection.requestMethod = httpOptions.method
-        
+
         // Set timeouts
         connection.connectTimeout = httpOptions.connectTimeout
         connection.readTimeout = httpOptions.readTimeout
-        
+
         // Set headers
         httpOptions.headers.forEach { (key, value) ->
             connection.setRequestProperty(key, value)
         }
-
-        val isHttpGET = httpOptions.method.equals("GET", ignoreCase = true)
-        val encodeParams = httpOptions.shouldEncodeUrlParams && isHttpGET
 
         // Set redirect handling
         connection.instanceFollowRedirects = !httpOptions.disableRedirects
@@ -77,17 +74,27 @@ internal class IONFLTRConnectionHelper {
             connection.sslSocketFactory = httpOptions.sslSocketFactory
         }
 
-        // Set parameters
-        var paramString = ""
+        return connection
+    }
+
+    /**
+     * append params to url, if applicable
+     */
+    fun appendParamsToUrl(
+        urlString: String,
+        connection: HttpURLConnection,
+        httpOptions: IONFLTRTransferHttpOptions,
+        useChunkedMode: Boolean
+    ): HttpURLConnection {
         if (httpOptions.params.isNotEmpty()) {
-            paramString = buildString {
+            val paramString = buildString {
                 httpOptions.params.forEach { (key, values) ->
                     values.forEach { value ->
                         if (isNotEmpty()) append("&")
-                        val encodedKey = if (encodeParams) {
+                        val encodedKey = if (httpOptions.shouldEncodeUrlParams) {
                             java.net.URLEncoder.encode(key, StandardCharsets.UTF_8.name())
                         } else key
-                        val encodedValue = if (encodeParams) {
+                        val encodedValue = if (httpOptions.shouldEncodeUrlParams) {
                             java.net.URLEncoder.encode(value, StandardCharsets.UTF_8.name())
                         } else value
                         append("$encodedKey=$encodedValue")
@@ -95,28 +102,21 @@ internal class IONFLTRConnectionHelper {
                 }
             }
 
-            // for requests other than GET, params will be written in the request body.
-            if (isHttpGET) {
+            // for HTTP requests that aren't for multipart/form-data, params will be written in the request body.
+            if (!useMultipartFormData(httpOptions) || useChunkedMode) {
                 val separator = if (urlString.contains("?")) "&" else "?"
                 val newUrl = URL("$urlString$separator$paramString")
-                return HttpConnectionSetup(
-                    connection = newUrl.openConnection() as HttpURLConnection,
-                    paramStringToWrite = ""
-                )
-            } else {
-                // TODO move this block elsewhere
-                /*connection.doOutput = true
-                connection.outputStream.use { os ->
-                    os.write(paramString.toByteArray())
-                }*/
+                return newUrl.openConnection() as HttpURLConnection
             }
         }
-        
-        return HttpConnectionSetup(connection = connection, paramStringToWrite = paramString)
+        return connection
     }
-}
 
-internal data class HttpConnectionSetup(
-    val connection: HttpURLConnection,
-    val paramStringToWrite: String
-)
+    /**
+     * @return true for any HTTP request that isn't a multipart/form-data
+     */
+    internal fun useMultipartFormData(options: IONFLTRTransferHttpOptions): Boolean =
+        !options.headers.containsKey("Content-Type") &&
+                (options.method.equals("POST", ignoreCase = true) || options.method.equals("PUT", ignoreCase = true))
+
+}


### PR DESCRIPTION
## Description

Fixes a bug where `uploadFile` with non-empty `httpOptions.params` would result in an error:

```java
java.lang.IllegalStateException: Cannot set request property after connection is made
```

The cause being `IONFLTRConnectionHelper#setupConnection` was writing params to the connection's `outputStream` for PUT and POST requests (which are typically for upload), and later we tried to call `connection.setRequestProperty`, but the connection was already ongoing, causing the exception.

The fix involved changing how params are passed. For `multipart/form-data`, the params are written in the body in that Content-Type's format, as it was already happening with `httpOptions.formData`(which may not actually be used atm, but was left for backwards compatibility). For any other kind of request, since the body for upload file will contain binary data, we set the params in the url, like it already happens for download.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Refer to these test apps from OutSystems that add params to downloads and uploads:

1. [Before (has error when trying to upload)](https://drive.google.com/file/d/1t2XOQ59ZUxRkcBLEh5no5nrbBAtl2RjF/view?usp=sharing)
2. [After (upload succeeds)](https://drive.google.com/file/d/1oaQS5L1fy14EKu9EVX8Y5Wsgq8bipqpx/view?usp=sharing)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly