### PR TITLE
Allow setting request body in file transfer download options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.4
+
+### 2026-02-09
+
+- Allow specifying a request body for file downloads
+
 ## 1.0.3
 
 ### 2026-01-08

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/IONFLTRController.kt
@@ -7,6 +7,7 @@ import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRFileHelper
 import io.ionic.libs.ionfiletransferlib.helpers.IONFLTRInputsValidator
 import io.ionic.libs.ionfiletransferlib.helpers.assertSuccessHttpResponse
 import io.ionic.libs.ionfiletransferlib.helpers.runCatchingIONFLTRExceptions
+import io.ionic.libs.ionfiletransferlib.helpers.setRequestBody
 import io.ionic.libs.ionfiletransferlib.helpers.use
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRDownloadOptions
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRProgressStatus
@@ -59,6 +60,9 @@ class IONFLTRController internal constructor(
             val (targetFile, connection) = prepareForDownload(options)
 
             connection.use { conn ->
+                // Set the request body if it's present
+                options.body?.let { conn.setRequestBody(it) }
+
                 // Execute the download and handle response
                 val contentLength = beginDownload(conn)
 

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRConnectionHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/helpers/IONFLTRConnectionHelper.kt
@@ -4,6 +4,7 @@ import io.ionic.libs.ionfiletransferlib.model.IONFLTRException
 import io.ionic.libs.ionfiletransferlib.model.IONFLTRTransferHttpOptions
 import java.net.HttpURLConnection
 import java.net.URL
+import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 
 /**
@@ -40,6 +41,43 @@ fun HttpURLConnection.assertSuccessHttpResponse() {
             it,
             headerFields
         )
+    }
+}
+
+fun HttpURLConnection.setRequestBody(
+    body: String,
+    charset: Charset = StandardCharsets.UTF_8,
+    contentType: String? = null,
+    useChunkedMode: Boolean = false,
+) {
+    val bytes = body.toByteArray(charset = charset)
+    setRequestBody(
+        bytes,
+        contentType?.let { "$it; charset=${charset.name()}" },
+        useChunkedMode
+    )
+}
+
+fun HttpURLConnection.setRequestBody(
+    bytes: ByteArray,
+    contentType: String? = null,
+    useChunkedMode: Boolean = false
+) {
+    if (contentType != null && this.getRequestProperty("Content-Type") == null) {
+        this.setRequestProperty("Content-Type", contentType);
+    }
+
+    this.doOutput = true
+
+    if (useChunkedMode) {
+        this.setChunkedStreamingMode(0)
+    } else {
+        this.setFixedLengthStreamingMode(bytes.size)
+    }
+
+    this.getOutputStream().use {
+        it.write(bytes)
+        it.flush()
     }
 }
 

--- a/src/main/kotlin/io/ionic/libs/ionfiletransferlib/model/IONFLTRTransferOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfiletransferlib/model/IONFLTRTransferOptions.kt
@@ -8,12 +8,36 @@ import javax.net.ssl.SSLSocketFactory
  * @property url The URL to download the file from
  * @property filePath The local path where the downloaded file will be saved
  * @property httpOptions Additional HTTP options for the download request
+ * @property body The request body as bytes
  */
 data class IONFLTRDownloadOptions(
     val url: String,
     val filePath: String,
-    val httpOptions: IONFLTRTransferHttpOptions = IONFLTRTransferHttpOptions("GET")
-)
+    val httpOptions: IONFLTRTransferHttpOptions = IONFLTRTransferHttpOptions("GET"),
+    val body: ByteArray? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as IONFLTRDownloadOptions
+
+        if (url != other.url) return false
+        if (filePath != other.filePath) return false
+        if (httpOptions != other.httpOptions) return false
+        if (!body.contentEquals(other.body)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url.hashCode()
+        result = 31 * result + filePath.hashCode()
+        result = 31 * result + httpOptions.hashCode()
+        result = 31 * result + (body?.contentHashCode() ?: 0)
+        return result
+    }
+}
 
 /**
  * Options for uploading a file


### PR DESCRIPTION
## Description

Adds the ability to pass a request body (as a `ByteArray`) to the download process.

The additional implementation of `equals` and `hashCode` were suggested by IntelliJ/Android Studio because of the `ByteArray`.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

I have tested it together with my PR to the capacitor file transfer plugin on a Samsung Galxy S22, where I download a blob from our backend which is identified via a protobuf request body.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly